### PR TITLE
Export Object.toConfig

### DIFF
--- a/config.go
+++ b/config.go
@@ -254,7 +254,7 @@ func (c *Config) WithFallback(fallback *Config) *Config {
 			resultConfig := fallbackObject.copy()
 			mergeObjects(resultConfig, current)
 
-			return resultConfig.toConfig()
+			return resultConfig.ToConfig()
 		}
 	}
 
@@ -308,8 +308,8 @@ func (o Object) String() string {
 	return builder.String()
 }
 
-// toConfig method converts object to *Config
-func (o Object) toConfig() *Config {
+// ToConfig method converts object to *Config
+func (o Object) ToConfig() *Config {
 	return &Config{o}
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -427,7 +427,7 @@ func TestSubstitution_String(t *testing.T) {
 
 func TestToConfig(t *testing.T) {
 	object := Object{"a": Int(1)}
-	got := object.toConfig()
+	got := object.ToConfig()
 	assertDeepEqual(t, got.root, object)
 }
 


### PR DESCRIPTION
This is useful when using a general config as fallback for one specific to the environment:

```HOCON
value1: abc
value2: def

prod {
   value2: ghi
}
```

```go
config, err := hocon.ParseResource("application.conf")
envConf := config.GetObject("prod")
if envConf != nil {
   config = envConf.ToConfig().WithFallback(config)
}
```