### PR TITLE
Adds GetConfig method

### DIFF
--- a/config.go
+++ b/config.go
@@ -46,6 +46,16 @@ func (c *Config) GetObject(path string) Object {
 	return value.(Object)
 }
 
+// GetConfig method finds the value at the given path and returns it as a Config, returns nil if the value is not found
+func (c *Config) GetConfig(path string) *Config {
+	value := c.GetObject(path)
+	if value == nil {
+		return nil
+	}
+
+	return value.ToConfig()
+}
+
 // GetStringMap method finds the value at the given path and returns it as a map[string]Value
 // returns nil if the value is not found
 func (c *Config) GetStringMap(path string) map[string]Value {

--- a/config_test.go
+++ b/config_test.go
@@ -36,6 +36,13 @@ func TestGetObject(t *testing.T) {
 	})
 }
 
+func TestGetConfig(t *testing.T) {
+	nestedConfig := &Config{Object{"b": String("c"), "d": Array{}}}
+	config := &Config{Object{"a": nestedConfig.root}}
+	got := config.GetConfig("a")
+	assertDeepEqual(t, got, nestedConfig)
+}
+
 func TestGetStringMap(t *testing.T) {
 	object := Object{"b": Int(1)}
 	config := &Config{Object{"a": object}}

--- a/config_test.go
+++ b/config_test.go
@@ -39,8 +39,18 @@ func TestGetObject(t *testing.T) {
 func TestGetConfig(t *testing.T) {
 	nestedConfig := &Config{Object{"b": String("c"), "d": Array{}}}
 	config := &Config{Object{"a": nestedConfig.root}}
-	got := config.GetConfig("a")
-	assertDeepEqual(t, got, nestedConfig)
+
+	t.Run("get nested config", func(t *testing.T) {
+		got := config.GetConfig("a")
+		assertDeepEqual(t, got, nestedConfig)
+	})
+
+	t.Run("return nil for non existing config", func(t *testing.T) {
+		got := config.GetConfig("b")
+		if got != nil {
+			t.Errorf("expected: nil, got: %v", got)
+		}
+	})
 }
 
 func TestGetStringMap(t *testing.T) {


### PR DESCRIPTION
Adds a method to get a subtree from the configuration, similar to the `getConfig` method in the Java library: https://lightbend.github.io/config/latest/api/com/typesafe/config/Config.html#getConfig-java.lang.String-