### PR TITLE
Use default value for optional env variables

### DIFF
--- a/config.go
+++ b/config.go
@@ -20,6 +20,7 @@ const (
 	NullType
 	SubstitutionType
 	ConcatenationType
+	stringWithAlternativeType
 )
 
 // Config stores the root of the configuration tree
@@ -285,6 +286,20 @@ type String string
 func (s String) Type() Type           { return StringType }
 func (s String) String() string       { return strings.Trim(string(s), `"`) }
 func (s String) isConcatenable() bool { return true }
+
+// stringWithAlternative represents a string value with Substitution which might override the original string value
+type stringWithAlternative struct {
+	value       String
+	alternative *Substitution
+}
+
+func (s *stringWithAlternative) Type() Type { return stringWithAlternativeType }
+
+func (s *stringWithAlternative) String() string {
+	return fmt.Sprintf("(%s | %s)", s.value, s.alternative.String())
+}
+
+func (s *stringWithAlternative) isConcatenable() bool { return false }
 
 // Object represents an object node in the configuration tree
 type Object map[string]Value

--- a/config_test.go
+++ b/config_test.go
@@ -442,6 +442,15 @@ func TestSubstitution_String(t *testing.T) {
 	})
 }
 
+func TestStringWithAlternative_String(t *testing.T) {
+	t.Run("return the string of string with alternative", func(t *testing.T) {
+		substitution := Substitution{path: "a", optional: false}
+		withAlt := stringWithAlternative{value: "value", alternative: &substitution}
+		got := withAlt.String()
+		assertEquals(t, got, "(value | ${a})")
+	})
+}
+
 func TestToConfig(t *testing.T) {
 	object := Object{"a": Int(1)}
 	got := object.ToConfig()

--- a/parser.go
+++ b/parser.go
@@ -163,19 +163,42 @@ func resolveSubstitutions(root Object, valueOptional ...Value) error {
 
 func processSubstitution(root Object, value Value, resolveFunc func(value Value)) error {
 	if valueType := value.Type(); valueType == SubstitutionType {
-		substitution := value.(*Substitution)
-		if foundValue := root.find(substitution.path); foundValue != nil {
-			resolveFunc(foundValue)
-		} else if env, ok := os.LookupEnv(substitution.path); ok {
-			resolveFunc(String(env))
-		} else if !substitution.optional {
-			return errors.New("could not resolve substitution: " + substitution.String() + " to a value")
+		processed, err := processSubstitutionType(root, value.(*Substitution))
+		if err != nil {
+			return err
 		}
+		resolveFunc(processed)
+		return nil
+	} else if valueType == stringWithAlternativeType {
+		withAlternative := value.(*stringWithAlternative)
+		if withAlternative.alternative != nil {
+			processed, err := processSubstitutionType(root, withAlternative.alternative)
+			if err != nil {
+				return err
+			}
+			if processed != nil {
+				resolveFunc(processed)
+				return nil
+			}
+		}
+		resolveFunc(withAlternative.value)
+		return nil
 	} else if valueType == ObjectType || valueType == ArrayType || valueType == ConcatenationType {
 		return resolveSubstitutions(root, value)
 	}
 
 	return nil
+}
+
+func processSubstitutionType(root Object, substitution *Substitution) (Value, error) {
+	if foundValue := root.find(substitution.path); foundValue != nil {
+		return foundValue, nil
+	} else if env, ok := os.LookupEnv(substitution.path); ok {
+		return String(env), nil
+	} else if !substitution.optional {
+		return nil, errors.New("could not resolve substitution: " + substitution.String() + " to a value")
+	}
+	return nil, nil
 }
 
 func (p *parser) extractObject(isSubObject ...bool) (Object, error) {
@@ -275,6 +298,16 @@ func (p *parser) extractObject(isSubObject ...bool) (Object, error) {
 					(existingValue.Type() == ObjectType && value.Type() == SubstitutionType) ||
 					(existingValue.Type() == SubstitutionType && value.Type() == ObjectType) {
 					value = concatenation{existingValue, value}
+				} else if existingValue.Type() == StringType && value.Type() == SubstitutionType {
+					value = &stringWithAlternative{
+						value:       existingValue.(String),
+						alternative: value.(*Substitution),
+					}
+				} else if existingValue.Type() == stringWithAlternativeType && value.Type() == SubstitutionType {
+					value = &stringWithAlternative{
+						value:       existingValue.(*stringWithAlternative).value,
+						alternative: value.(*Substitution),
+					}
 				}
 			}
 


### PR DESCRIPTION
This change should fix issue https://github.com/gurkankaymak/hocon/issues/8 

Introduces new String() syntax. For config: `a: "value", a: "$?ENV}` will be returned "(value | ${?ENV})"

If more than one alternative is provided:  `a: "value", a: "${REQUIRED}, a: ${?OPTIONAL}` the first substitution will never be resolved - error won't be returned even if substitution is invalid.

Documentation does not mention how to handle such case, but maybe for config: `a: "value", a: "${?PRESENT}, a:$?ABSENT}` and env variable PRESENT being set and ABSENT not being set, value of PRESENT should be returned?
Current implementation will return "value".