### PR TITLE
Fixed included resource path resolution

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -997,11 +997,11 @@ func TestParseIncludedResource(t *testing.T) {
 	})
 
 	t.Run("parse the included resource and return the parsed object if there is no error", func(t *testing.T) {
-		parser := newParser(strings.NewReader(`include "testdata/a.conf"`))
-		advanceScanner(t, parser, `"testdata/a.conf"`)
+		parser := newParser(strings.NewReader(`include "testdata/x.conf"`))
+		advanceScanner(t, parser, `"testdata/x.conf"`)
 		got, err := parser.parseIncludedResource()
 		assertNoError(t, err)
-		assertDeepEqual(t, got, Object{"a": Int(1)})
+		assertDeepEqual(t, got, Object{"a": Int(1), "x": Int(7), "y": String("foo")})
 	})
 }
 

--- a/testdata/nested/y.conf
+++ b/testdata/nested/y.conf
@@ -1,0 +1,2 @@
+include required("../a.conf")
+y:"foo"

--- a/testdata/x.conf
+++ b/testdata/x.conf
@@ -1,0 +1,2 @@
+include required("nested/y.conf")
+x:7


### PR DESCRIPTION
Fixes https://github.com/gurkankaymak/hocon/issues/28

I originally hoped to just work around this bug, but it proved to be particularly frustrating when trying to load config files from multiple different working directories within my project (test suites, running apps locally, running apps in docker).

Verified that the modified test breaks without these changes, and that it passes with them.