### PR TITLE
Fixed trailing comma comments bug

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -633,7 +633,12 @@ func (p *parser) extractArray() (Array, error) {
 
 			token = p.scanner.TokenText()
 
-			if p.scanner.TokenText() == commaToken {
+			if token == commentToken {
+				p.consumeComment()
+				token = p.scanner.TokenText()
+			}
+
+			if token == commaToken {
 				return nil, adjacentCommasError(p.scanner.Line, p.scanner.Column)
 			}
 		}

--- a/parser_test.go
+++ b/parser_test.go
@@ -1172,6 +1172,14 @@ func TestExtractArray(t *testing.T) {
 		assertDeepEqual(t, got, Array{Int(1)})
 	})
 
+	t.Run("extract the array without an error when the trailing comma is followed by a comment", func(t *testing.T) {
+		parser := newParser(strings.NewReader("[1,#comment\n]"))
+		parser.advance()
+		got, err := parser.extractArray()
+		assertNoError(t, err)
+		assertDeepEqual(t, got, Array{Int(1)})
+	})
+
 	t.Run("extract the array without an error if if elements are separated with ASCII newline", func(t *testing.T) {
 		parser := newParser(strings.NewReader("[1\n2]"))
 		parser.advance()


### PR DESCRIPTION
Fixes #41

If an array has a trailing comma, and that comma is followed by a comment before the array is terminated, this ensures that it parses successfully.