### PR TITLE
fix comment parsing between include statements

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -253,11 +253,12 @@ func (p *parser) extractObject(isSubObject ...bool) (Object, error) {
 	lastRow := 0
 
 	for tok := p.scanner.Peek(); tok != scanner.EOF; tok = p.scanner.Peek() {
-		for p.scanner.TokenText() == commentToken {
+		if p.scanner.TokenText() == commentToken {
 			p.consumeComment()
+			continue
 		}
 
-		for p.scanner.TokenText() == includeToken {
+		if p.scanner.TokenText() == includeToken {
 			p.advance()
 
 			includedObject, err := p.parseIncludedResource()
@@ -267,6 +268,7 @@ func (p *parser) extractObject(isSubObject ...bool) (Object, error) {
 
 			mergeObjects(object, includedObject)
 			p.advance()
+			continue
 		}
 
 		if !parenthesisBalanced && p.scanner.TokenText() == objectEndToken {

--- a/parser_test.go
+++ b/parser_test.go
@@ -223,6 +223,19 @@ func TestExtractObject(t *testing.T) {
 		assertDeepEqual(t, got, expected)
 	})
 
+	t.Run("parse a comment between two includes", func(t *testing.T) {
+		parser := newParser(strings.NewReader(
+			`include "testdata/a.conf"
+			# comment
+			include "testdata/b.conf"
+		`))
+		parser.advance()
+		expected := Object{"a": Int(1), "b": Int(2)}
+		got, err := parser.extractObject()
+		assertNoError(t, err)
+		assertDeepEqual(t, got, expected)
+	})
+
 	t.Run("parse correctly if the last line is a comment", func(t *testing.T) {
 		config := `{
 			a: 1


### PR DESCRIPTION
I believe the problem with parsing comments between include statements was that the include handler was running in a loop and needed to jump back to the comment handler. Changing the `for` loop to an `if` block with a `continue` fixes the problem.

I also changed the comment handler loop to match the same pattern, but surely that doesn't have any effect on the behavior. I just thought it made more sense to be consistent between the two blocks.