### PR TITLE
fix panic caused by nil pointer dereference

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -302,6 +302,9 @@ func TestWithFallback(t *testing.T) {
 	config1 := &Config{Object{"a": String("aa"), "b": String("bb")}}
 	config2 := &Config{Object{"a": String("aaa"), "c": String("cc")}}
 	config3 := &Config{Array{Int(1), Int(2)}}
+	config4 := &Config{Object{"a": String("aa")}}
+	config5 := &Config{Object{"a": nil}}
+	config6 := &Config{Object{"a": Object{"a": String("aa"), "b": String("bb")}}}
 
 	t.Run("merge the given fallback config with the current config if the root of both of them are of type Object (for the same keys current config should override the fallback)", func(t *testing.T) {
 		expected := &Config{Object{"a": String("aa"), "b": String("bb"), "c": String("cc")}}
@@ -317,6 +320,21 @@ func TestWithFallback(t *testing.T) {
 	t.Run("return the current config if the root of it is not an Object", func(t *testing.T) {
 		got := config3.WithFallback(config1)
 		assertDeepEqual(t, got, config3)
+	})
+
+	t.Run("return the current value if new value is nil", func(t *testing.T) {
+		got := config4.WithFallback(config5)
+		assertDeepEqual(t, got, config4)
+	})
+
+	t.Run("rewrite the current value if old value is nil and new value is not nil", func(t *testing.T) {
+		got := config5.WithFallback(config4)
+		assertDeepEqual(t, got, config4)
+	})
+
+	t.Run("rewrite the current value if old value is nil and new value is not nil and Object", func(t *testing.T) {
+		got := config5.WithFallback(config6)
+		assertDeepEqual(t, got, config6)
 	})
 }
 

--- a/parser.go
+++ b/parser.go
@@ -418,13 +418,15 @@ func (p *parser) extractObject(isSubObject ...bool) (Object, error) {
 func mergeObjects(existing Object, new Object) {
 	for key, value := range new {
 		existingValue, ok := existing[key]
-		if ok && existingValue.Type() == ObjectType && value.Type() == ObjectType {
+		if ok && existingValue != nil && existingValue.Type() == ObjectType && value != nil &&
+			value.Type() == ObjectType {
 			existingObj := existingValue.(Object)
 			mergeObjects(existingObj, value.(Object))
 			value = existingObj
 		}
-
-		existing[key] = value
+		if value != nil {
+			existing[key] = value
+		}
 	}
 }
 


### PR DESCRIPTION
This PR fixes panic when one of the values is nil during WithFallback call
Example
First file
```
{
    "a":${?a} // no env variable found
}
```
Second file
```
{
    "a":"hello"
}
```