### PR TITLE
fix env vars always resolve as strings

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -225,7 +225,9 @@ func processSubstitutionType(root Object, substitution *Substitution, visitedPat
 		delete(visitedPaths, substitution.path)
 		return foundValue, nil
 	} else if env, ok := os.LookupEnv(substitution.path); ok {
-		return String(env), nil
+		p := newParser(strings.NewReader(env))
+		p.advance()
+		return p.extractValue()
 	} else if !substitution.optional {
 		return nil, errors.New("could not resolve substitution: " + substitution.String() + " to a value")
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -680,6 +680,43 @@ func TestResolveSubstitutions(t *testing.T) {
 			t.Errorf("expected value: %s from environment variable: %s, got: %s", expected, testEnv, object["a"])
 		}
 	})
+	t.Run("resolve duration environment variable", func(t *testing.T) {
+		gotString, err := ParseString("{a:1s}")
+		assertNoError(t, err)
+		testEnv := "TEST_ENV"
+		err = os.Setenv(testEnv, "1s")
+		assertNoError(t, err)
+		gotEnv, err := ParseString("{a:${TEST_ENV}}")
+		assertNoError(t, err)
+		err = os.Unsetenv(testEnv)
+		assertNoError(t, err)
+		assertEquals(t, gotString.GetDuration("a"), gotEnv.GetDuration("a"))
+	})
+	t.Run("resolve array environment variable", func(t *testing.T) {
+		gotString, err := ParseString("{a:[1s, 2s]}")
+		assertNoError(t, err)
+		testEnv := "TEST_ENV"
+		err = os.Setenv(testEnv, "[1s, 2s]")
+		assertNoError(t, err)
+		gotEnv, err := ParseString("{a:${TEST_ENV}}")
+		assertNoError(t, err)
+		err = os.Unsetenv(testEnv)
+		assertNoError(t, err)
+		assertEquals(t, gotString.GetArray("a").String(), gotEnv.GetArray("a").String())
+	})
+	t.Run("resolve structured environment variable", func(t *testing.T) {
+		gotString, err := ParseString("{a:{b:1s, c:{d:2}}}")
+		assertNoError(t, err)
+		testEnv := "TEST_ENV"
+		err = os.Setenv(testEnv, "{b:1s, c:{d:2}}")
+		assertNoError(t, err)
+		gotEnv, err := ParseString("{a:${TEST_ENV}}")
+		assertNoError(t, err)
+		err = os.Unsetenv(testEnv)
+		assertNoError(t, err)
+		assertEquals(t, gotString.GetDuration("a.b"), gotEnv.GetDuration("a.b"))
+		assertEquals(t, gotString.GetInt("a.c.d"), gotEnv.GetInt("a.c.d"))
+	})
 
 	t.Run("resolve to the static value if substitution path does not exist and environment variable is not set and default value was not provided", func(t *testing.T) {
 		defaultValue := String("default")


### PR DESCRIPTION
This PR fix bug, when all env variables always resolve as strings

**Current state**
```go
cfg, _ := hocon.ParseString("{a:1s, b:[hello, world]}")
fmt.Println(reflect.TypeOf(cfg.Get("a")))                             // hocon.Duration
fmt.Println(reflect.TypeOf(cfg.Get("b")))                             // hocon.Array
```

```go
os.Setenv("TIME_ENV", "1s")
os.Setenv("ARRAY_ENV", "[hello, world]")
cfg, _ = hocon.ParseString("{a:${TIME_ENV}, b: ${ARRAY_ENV}}")
fmt.Println(reflect.TypeOf(cfg.Get("a")))                             // hocon.String
fmt.Println(reflect.TypeOf(cfg.Get("b")))                             // hocon.String
```

**After fix**
```go
os.Setenv("TIME_ENV", "1s")
os.Setenv("ARRAY_ENV", "[hello, world]")
cfg, _ = hocon.ParseString("{a:${TIME_ENV}, b: ${ARRAY_ENV}}")
fmt.Println(reflect.TypeOf(cfg.Get("a")))                             // hocon.Duration
fmt.Println(reflect.TypeOf(cfg.Get("b")))                             // hocon.Array
```